### PR TITLE
polish the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS= -Wall -g -I.
+CFLAGS= -Wall -g
 OBJS= sha1.o
 LIBS= -lsqlite3
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,11 @@
-CC=gcc
-PRF=-O2
-PROFILE=
 CFLAGS= -Wall -g -I.
 OBJS= sha1.o
 LIBS= -lsqlite3
 
 all: ideviceunback
 
-.c.o:
-	$(CC) $(CFLAGS) -c $*.c
-
 ideviceunback: $(OBJS) ideviceunback.c
 	gcc $(CFLAGS) ideviceunback.c $(OBJS) -o ideviceunback  $(LIBS)
-
-default: ideviceunback
 
 clean:
 	rm ideviceunback *.o


### PR DESCRIPTION
This is a work in progress. (In case you don't like it.)

These lines are not actually necessary.

 1. The 'default' target is unnecessary; default target (that is, when you run `make` without explicit target) of GNU Make is the first one (`all` in this file), unless there is some other tool explicitly running `make default`.
 2. I don't see `PRF` or `PROFILE` used anywhere.
 3. `.c.o` as a target is unnecessary, because GNU Make has built-in rule for it. See [*Catalogue of Built-In Rules*](https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html#Catalogue-of-Rules) in the manual.
 4. `CC` defaults to the C compiler in the operating system. On some it is `cc`, which links to a C compiler according to user's preference. For example some user (like me) would like to use Clang instead of GCC. Or is there any issue when compiled with Clang? (In that case it would probably be Clang's bug.)